### PR TITLE
Create simple MAUI gallery page

### DIFF
--- a/Gallery/MainPage.xaml
+++ b/Gallery/MainPage.xaml
@@ -3,34 +3,48 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Gallery.MainPage">
 
-    <ScrollView>
-        <VerticalStackLayout
-            Padding="30,0"
-            Spacing="25">
-            <Image
-                Source="dotnet_bot.png"
-                HeightRequest="185"
-                Aspect="AspectFit"
-                SemanticProperties.Description="dot net bot in a race car number eight" />
-
-            <Label
-                Text="Hello, World!"
-                Style="{StaticResource Headline}"
-                SemanticProperties.HeadingLevel="Level1" />
-
-            <Label
-                Text="Welcome to &#10;.NET Multi-platform App UI"
-                Style="{StaticResource SubHeadline}"
-                SemanticProperties.HeadingLevel="Level2"
-                SemanticProperties.Description="Welcome to dot net Multi platform App U I" />
-
-            <Button
-                x:Name="CounterBtn"
-                Text="Click me" 
-                SemanticProperties.Hint="Counts the number of times you click"
-                Clicked="OnCounterClicked"
-                HorizontalOptions="Fill" />
+    <Grid Padding="24" RowSpacing="12" ColumnDefinitions="*" RowDefinitions="Auto,*">
+        <VerticalStackLayout Grid.Row="0" Spacing="4">
+            <Label Text="Simple Photo Gallery"
+                   Style="{StaticResource Headline}"
+                   SemanticProperties.HeadingLevel="Level1" />
+            <Label Text="A lightweight collection of remote photos"
+                   Style="{StaticResource Body}"
+                   TextColor="Gray" />
         </VerticalStackLayout>
-    </ScrollView>
+
+        <CollectionView Grid.Row="1"
+                        ItemsSource="{Binding Images}"
+                        SelectionMode="None"
+                        Margin="0,12,0,0">
+            <CollectionView.ItemsLayout>
+                <GridItemsLayout Orientation="Vertical" Span="2" />
+            </CollectionView.ItemsLayout>
+
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <Frame HasShadow="False"
+                           BorderColor="#dddddd"
+                           CornerRadius="12"
+                           Padding="12"
+                           Margin="6">
+                        <VerticalStackLayout Spacing="8">
+                            <Image Source="{Binding Source}"
+                                   Aspect="AspectFill"
+                                   HeightRequest="120"
+                                   SemanticProperties.Description="{Binding Description}" />
+                            <Label Text="{Binding Title}"
+                                   FontAttributes="Bold"
+                                   LineBreakMode="TailTruncation" />
+                            <Label Text="{Binding Description}"
+                                   Style="{StaticResource Caption}"
+                                   TextColor="Gray"
+                                   LineBreakMode="WordWrap" />
+                        </VerticalStackLayout>
+                    </Frame>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+    </Grid>
 
 </ContentPage>

--- a/Gallery/MainPage.xaml.cs
+++ b/Gallery/MainPage.xaml.cs
@@ -1,25 +1,43 @@
-﻿namespace Gallery
+using System.Collections.ObjectModel;
+
+namespace Gallery
 {
     public partial class MainPage : ContentPage
     {
-        int count = 0;
+        public ObservableCollection<GalleryItem> Images { get; } = new();
 
         public MainPage()
         {
             InitializeComponent();
-        }
+            BindingContext = this;
 
-        private void OnCounterClicked(object sender, EventArgs e)
-        {
-            count++;
+            Images.Add(new GalleryItem(
+                "Mountain Sunrise",
+                "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?w=600",
+                "Warm light spilling over a mountain range."));
 
-            if (count == 1)
-                CounterBtn.Text = $"Clicked {count} time";
-            else
-                CounterBtn.Text = $"Clicked {count} times";
+            Images.Add(new GalleryItem(
+                "Forest Trail",
+                "https://images.unsplash.com/photo-1501785888041-af3ef285b470?w=600",
+                "A calm walk through dense woodland."));
 
-            SemanticScreenReader.Announce(CounterBtn.Text);
+            Images.Add(new GalleryItem(
+                "City Nights",
+                "https://images.unsplash.com/photo-1499346030926-9a72daac6c63?w=600",
+                "Skyscrapers glowing after dusk."));
+
+            Images.Add(new GalleryItem(
+                "Beach Escape",
+                "https://images.unsplash.com/photo-1507525428034-b723cf961d3e?w=600",
+                "Turquoise water brushing against soft sand."));
+
+            Images.Add(new GalleryItem(
+                "Desert Journey",
+                "https://images.unsplash.com/photo-1500530855697-9fef9a48d3d8?w=600",
+                "Rolling dunes under a clear sky."));
         }
     }
+
+    public record GalleryItem(string Title, string Source, string Description);
 
 }


### PR DESCRIPTION
## Summary
- replace the starter counter layout with a simple gallery presentation
- bind a collection of remote sample images to the gallery view

## Testing
- `dotnet build Gallery.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e7a8428e84832b9dbe84accffd97ba